### PR TITLE
/query parameters

### DIFF
--- a/transformer/src/parsers/doc/detail_page.rs
+++ b/transformer/src/parsers/doc/detail_page.rs
@@ -73,10 +73,7 @@ impl<'a> TryFrom<&scraper::ElementRef<'a>> for DefinitionListValue {
 
 impl DefinitionListValue {
     pub fn text_to_markdown(&self) -> Option<String> {
-        match self {
-            DefinitionListValue::Text(html) => Some(html2md::parse_html(html).trim().into()),
-            DefinitionListValue::SubList(_) => None,
-        }
+        self.as_text().map(|h| html2md::parse_html(h).trim().into())
     }
 
     pub fn as_text(&self) -> Option<&str> {

--- a/transformer/src/parsers/doc/operation.rs
+++ b/transformer/src/parsers/doc/operation.rs
@@ -268,18 +268,18 @@ impl From<Operation> for openapiv3::Operation {
                 .map(|qp| {
                     openapiv3::ReferenceOr::Item(openapiv3::Parameter::Query {
                         parameter_data: openapiv3::ParameterData {
-                            name: qp.name,
                             description: qp.description,
                             required: false,
                             deprecated: None,
                             format: openapiv3::ParameterSchemaOrContent::Schema(
-                                openapiv3::ReferenceOr::Item(openapiv3::Schema {
-                                    schema_kind: openapiv3::SchemaKind::Type(
-                                        openapiv3::Type::String(Default::default()),
+                                openapiv3::ReferenceOr::Reference {
+                                    reference: format!(
+                                        "#/components/schemas/query-parameter_{}",
+                                        qp.name
                                     ),
-                                    schema_data: Default::default(),
-                                }),
+                                },
                             ),
+                            name: qp.name,
                             example: None,
                             examples: Default::default(),
                         },
@@ -377,7 +377,7 @@ fn generate_schema_test() {
               "name": "force",
               "description": "Documentation for force",
               "schema": {
-                "type": "string"
+                "$ref": "#/components/schemas/query-parameter_force"
               },
               "style": "form"
             },
@@ -385,7 +385,7 @@ fn generate_schema_test() {
               "in": "query",
               "name": "recursive",
               "schema": {
-                "type": "string"
+                "$ref": "#/components/schemas/query-parameter_recursive"
               },
               "style": "form"
             }

--- a/transformer/src/parsers/doc/operation.rs
+++ b/transformer/src/parsers/doc/operation.rs
@@ -105,14 +105,15 @@ impl<'a> TryFrom<(DetailPage, &BTreeMap<String, String>, String)> for Operation 
         } else {
             "user"
         };
-        let request_content_type = match p.definition_list.0.get("Input parameters") {
-            Some(DefinitionListValue::SubList(b)) => match b.0.get("Consume media type(s):") {
-                Some(DefinitionListValue::Text(t)) => t.split("+xml<br>").next(),
-                _ => None,
-            },
-            _ => None,
-        }
-        .map(str::to_string);
+        let request_content_type = p
+            .definition_list
+            .0
+            .get("Input parameters")
+            .and_then(DefinitionListValue::as_sublist)
+            .and_then(|l| l.0.get("Consume media type(s):"))
+            .and_then(DefinitionListValue::as_text)
+            .and_then(|t| t.split("+xml<br>").next())
+            .map(str::to_string);
 
         let request_content_ref = request_content_type
             .as_ref()
@@ -124,14 +125,15 @@ impl<'a> TryFrom<(DetailPage, &BTreeMap<String, String>, String)> for Operation 
             _ => None,
         };
 
-        let response_content_type = match p.definition_list.0.get("Output parameters") {
-            Some(DefinitionListValue::SubList(b)) => match b.0.get("Produce media type(s):") {
-                Some(DefinitionListValue::Text(t)) => t.split("+xml<br>").next(),
-                _ => None,
-            },
-            _ => None,
-        }
-        .map(str::to_string);
+        let response_content_type = p
+            .definition_list
+            .0
+            .get("Output parameters")
+            .and_then(DefinitionListValue::as_sublist)
+            .and_then(|l| l.0.get("Produce media type(s):"))
+            .and_then(DefinitionListValue::as_text)
+            .and_then(|t| t.split("+xml<br>").next())
+            .map(str::to_string);
 
         let response_content_ref = response_content_type
             .as_ref()

--- a/transformer/src/parsers/doc/operations/PUT-Test.html
+++ b/transformer/src/parsers/doc/operations/PUT-Test.html
@@ -32,6 +32,19 @@
                 <dd><a href="..//types/AdminTestType.html">AdminTestType</a></dd>
             </dl>
         </dd>
+        <dt>Query parameters</dt>
+        <dd>
+            <dl>
+                                   <dt>Parameter</dt>
+                   <dd>force</dd>
+                   <dt>Documentation</dt>
+                   <dd>Documentation for force</dd>
+                                   <dt>Parameter</dt>
+                   <dd>recursive</dd>
+                   <dt>Documentation</dt>
+                   <dd></dd>
+                            </dl>
+        </dd>
         <dt>Output parameters</dt>
         <dd>
             AdminTestType<br><br>

--- a/transformer/src/schemas.rs
+++ b/transformer/src/schemas.rs
@@ -14,7 +14,7 @@ pub fn schemas<R: Read + Seek>(
     ),
     Box<dyn std::error::Error>,
 > {
-    let mut output = IndexMap::new();
+    let mut output = query_parameters();
     let mut type_file_names = zip
         .file_names()
         .filter(|n| n.starts_with("doc/etc/"))
@@ -98,4 +98,137 @@ pub fn schemas<R: Read + Seek>(
     );
 
     Ok((output, content_type_mapping))
+}
+
+fn query_parameters() -> IndexMap<String, ReferenceOr<Schema>> {
+    [
+        (
+            "force",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::Boolean {}),
+            }),
+        ),
+        (
+            "recursive",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::Boolean {}),
+            }),
+        ),
+        (
+            "fields",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::String(
+                    Default::default(),
+                )),
+            }),
+        ),
+        (
+            "filter",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::String(
+                    Default::default(),
+                )),
+            }),
+        ),
+        (
+            "filterEncoded",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::Boolean {}),
+            }),
+        ),
+        (
+            "format",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::String(
+                    openapiv3::StringType {
+                        enumeration: ["references", "records", "idrecords"]
+                            .iter()
+                            .map(|e| e.to_string())
+                            .collect(),
+                        ..Default::default()
+                    },
+                )),
+            }),
+        ),
+        (
+            "links",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::Boolean {}),
+            }),
+        ),
+        (
+            "offset",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::Integer(
+                    openapiv3::IntegerType {
+                        minimum: Some(0),
+                        ..Default::default()
+                    },
+                )),
+            }),
+        ),
+        (
+            "page",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::Integer(
+                    openapiv3::IntegerType {
+                        minimum: Some(1),
+                        ..Default::default()
+                    },
+                )),
+            }),
+        ),
+        (
+            "pageSize",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::Integer(
+                    openapiv3::IntegerType {
+                        minimum: Some(1),
+                        maximum: Some(128),
+                        ..Default::default()
+                    },
+                )),
+            }),
+        ),
+        (
+            "sortAsc",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::String(
+                    Default::default(),
+                )),
+            }),
+        ),
+        (
+            "sortDesc",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::String(
+                    Default::default(),
+                )),
+            }),
+        ),
+        (
+            "type",
+            ReferenceOr::Item(Schema {
+                schema_data: Default::default(),
+                schema_kind: openapiv3::SchemaKind::Type(openapiv3::Type::String(
+                    Default::default(),
+                )),
+            }),
+        ),
+    ]
+    .iter()
+    .map(|(name, schema)| (format!("query-parameter_{}", name), schema.clone()))
+    .collect()
 }

--- a/website/27.0.json
+++ b/website/27.0.json
@@ -19744,6 +19744,54 @@
       }
     },
     "schemas": {
+      "query-parameter_force": {
+        "type": "boolean"
+      },
+      "query-parameter_recursive": {
+        "type": "boolean"
+      },
+      "query-parameter_fields": {
+        "type": "string"
+      },
+      "query-parameter_filter": {
+        "type": "string"
+      },
+      "query-parameter_filterEncoded": {
+        "type": "boolean"
+      },
+      "query-parameter_format": {
+        "type": "string",
+        "enum": [
+          "references",
+          "records",
+          "idrecords"
+        ]
+      },
+      "query-parameter_links": {
+        "type": "boolean"
+      },
+      "query-parameter_offset": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "query-parameter_page": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "query-parameter_pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128
+      },
+      "query-parameter_sortAsc": {
+        "type": "string"
+      },
+      "query-parameter_sortDesc": {
+        "type": "string"
+      },
+      "query-parameter_type": {
+        "type": "string"
+      },
       "vcloud_AmqpConfigurationType": {
         "title": "vcloud_AmqpConfigurationType",
         "description": "Represents a list of AMQP Configuration items",

--- a/website/29.0.json
+++ b/website/29.0.json
@@ -3176,6 +3176,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_SiteType"
                 }
+              },
+              "application/vnd.vmware.admin.siteAssociation+json;version=29.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_SiteAssociationType"
+                }
               }
             }
           }

--- a/website/29.0.json
+++ b/website/29.0.json
@@ -413,6 +413,24 @@
           "admin"
         ],
         "description": "Delete a catalog.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -971,6 +989,24 @@
           "admin"
         ],
         "description": "Delete an edge gateway.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1378,6 +1414,24 @@
           "user"
         ],
         "description": "Delete a media object.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1564,6 +1618,24 @@
           "admin"
         ],
         "description": "Delete a network.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1917,6 +1989,26 @@
           "admin"
         ],
         "description": "Delete an organization.\n\n Before you can delete an organization, you must disable it and then delete or change ownership of all objects that the organization's users own.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3446,6 +3538,24 @@
           "user"
         ],
         "description": "Delete a vApp or VM.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3825,6 +3935,24 @@
           "admin"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3917,6 +4045,24 @@
           "user"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it, unless {@code RestConstants.DeleteParameters.FORCE} is asserted",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -5529,6 +5675,88 @@
           "user"
         ],
         "description": "Retrieves a list of Catalogs by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -5951,6 +6179,88 @@
           "extension"
         ],
         "description": "Get a list of all datastores by using REST API General QueryHandler. This is read only list of datastores. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6174,6 +6484,88 @@
           "user"
         ],
         "description": "Retrieves a disk list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6446,6 +6838,96 @@
           "user"
         ],
         "description": "REST API General queries handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6572,6 +7054,88 @@
           "extension"
         ],
         "description": "Get list of external networks by using REST API general QueryHandler. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6835,6 +7399,88 @@
           "admin"
         ],
         "description": "Retrieves a list of groups for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7182,6 +7828,88 @@
           "extension"
         ],
         "description": "Get list of hosts by using REST API general QueryHAndler; This is read only list of host references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7907,6 +8635,88 @@
           "user"
         ],
         "description": "Retrieves a media list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -8703,6 +9513,88 @@
           "extension"
         ],
         "description": "Get list of network pools by using REST API general QueryHandler. This is read only list of network pool references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9199,6 +10091,88 @@
           "extension"
         ],
         "description": "Get list of Organization Networks for the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9506,6 +10480,88 @@
           "extension"
         ],
         "description": "Get list of all Organization Vdcs in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9780,6 +10836,88 @@
           "admin"
         ],
         "description": "Retrieves a list of organizations by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10193,6 +11331,88 @@
           "extension"
         ],
         "description": "Get list of provider vDCs by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10494,6 +11714,88 @@
           "admin"
         ],
         "description": "Retrieves a list of vdcs in the organization; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10512,6 +11814,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10541,6 +11925,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11283,6 +12749,88 @@
           "extension"
         ],
         "description": "Return the System Administrator representation of all extension services registered with the system.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11556,6 +13104,88 @@
           "extension"
         ],
         "description": "Get list of all stranded items in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11873,6 +13503,88 @@
           "admin"
         ],
         "description": "Retrieves a list of users for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12317,6 +14029,88 @@
           "user"
         ],
         "description": "Retrieves a list of vAppTemplates using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12335,6 +14129,88 @@
           "extension"
         ],
         "description": "Get list of all vApps in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12371,6 +14247,88 @@
           "user"
         ],
         "description": "Retrieves a list of VMs in lease by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13140,6 +15098,88 @@
           "extension"
         ],
         "description": "Get list of vSphere servers by using REST API general QueryHandler; This is read only list of vim servers and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13929,6 +15969,24 @@
           "extension"
         ],
         "description": "Retrieve a list of virtual machines that can be imported from a registered vCenter server.\n\n This request supports optional query parameters:\n\n* page \\- The page to return. The first page is page 1.\n* pageSize \\- The number of virtual machines to list on a page. An integer value between 1 and 100. The default value is 1.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/29.0.json
+++ b/website/29.0.json
@@ -418,7 +418,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -426,7 +426,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -994,7 +994,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1002,7 +1002,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1419,7 +1419,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1427,7 +1427,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1623,7 +1623,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1631,7 +1631,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1995,7 +1995,7 @@
             "name": "force",
             "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -2004,7 +2004,7 @@
             "name": "recursive",
             "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3543,7 +3543,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3551,7 +3551,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3940,7 +3940,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3948,7 +3948,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4050,7 +4050,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4058,7 +4058,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -5680,7 +5680,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -5688,7 +5688,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -5696,7 +5696,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -5704,7 +5704,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -5712,7 +5712,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -5720,7 +5720,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -5728,7 +5728,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -5736,7 +5736,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -5744,7 +5744,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -5752,7 +5752,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6184,7 +6184,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6192,7 +6192,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6200,7 +6200,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6208,7 +6208,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6216,7 +6216,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6224,7 +6224,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6232,7 +6232,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6240,7 +6240,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6248,7 +6248,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6256,7 +6256,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6489,7 +6489,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6497,7 +6497,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6505,7 +6505,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6513,7 +6513,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6521,7 +6521,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6529,7 +6529,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6537,7 +6537,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6545,7 +6545,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6553,7 +6553,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6561,7 +6561,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6843,7 +6843,7 @@
             "in": "query",
             "name": "type",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_type"
             },
             "style": "form"
           },
@@ -6851,7 +6851,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6859,7 +6859,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6867,7 +6867,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6875,7 +6875,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6883,7 +6883,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6891,7 +6891,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6899,7 +6899,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6907,7 +6907,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6915,7 +6915,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6923,7 +6923,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7059,7 +7059,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7067,7 +7067,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7075,7 +7075,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7083,7 +7083,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7091,7 +7091,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7099,7 +7099,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7107,7 +7107,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7115,7 +7115,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7123,7 +7123,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7131,7 +7131,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7404,7 +7404,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7412,7 +7412,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7420,7 +7420,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7428,7 +7428,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7436,7 +7436,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7444,7 +7444,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7452,7 +7452,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7460,7 +7460,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7468,7 +7468,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7476,7 +7476,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7833,7 +7833,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7841,7 +7841,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7849,7 +7849,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7857,7 +7857,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7865,7 +7865,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7873,7 +7873,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7881,7 +7881,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7889,7 +7889,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7897,7 +7897,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7905,7 +7905,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -8640,7 +8640,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -8648,7 +8648,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -8656,7 +8656,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -8664,7 +8664,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -8672,7 +8672,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -8680,7 +8680,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -8688,7 +8688,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -8696,7 +8696,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -8704,7 +8704,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -8712,7 +8712,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -9518,7 +9518,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -9526,7 +9526,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -9534,7 +9534,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -9542,7 +9542,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -9550,7 +9550,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -9558,7 +9558,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -9566,7 +9566,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -9574,7 +9574,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -9582,7 +9582,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -9590,7 +9590,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10096,7 +10096,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10104,7 +10104,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10112,7 +10112,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10120,7 +10120,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10128,7 +10128,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10136,7 +10136,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10144,7 +10144,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10152,7 +10152,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10160,7 +10160,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10168,7 +10168,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10485,7 +10485,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10493,7 +10493,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10501,7 +10501,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10509,7 +10509,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10517,7 +10517,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10525,7 +10525,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10533,7 +10533,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10541,7 +10541,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10549,7 +10549,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10557,7 +10557,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10841,7 +10841,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10849,7 +10849,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10857,7 +10857,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10865,7 +10865,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10873,7 +10873,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10881,7 +10881,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10889,7 +10889,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10897,7 +10897,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10905,7 +10905,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10913,7 +10913,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11336,7 +11336,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11344,7 +11344,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11352,7 +11352,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11360,7 +11360,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11368,7 +11368,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11376,7 +11376,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11384,7 +11384,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11392,7 +11392,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11400,7 +11400,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11408,7 +11408,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11719,7 +11719,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11727,7 +11727,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11735,7 +11735,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11743,7 +11743,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11751,7 +11751,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11759,7 +11759,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11767,7 +11767,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11775,7 +11775,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11783,7 +11783,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11791,7 +11791,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11819,7 +11819,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11827,7 +11827,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11835,7 +11835,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11843,7 +11843,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11851,7 +11851,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11859,7 +11859,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11867,7 +11867,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11875,7 +11875,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11883,7 +11883,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11891,7 +11891,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11930,7 +11930,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11938,7 +11938,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11946,7 +11946,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11954,7 +11954,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11962,7 +11962,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11970,7 +11970,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11978,7 +11978,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11986,7 +11986,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11994,7 +11994,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12002,7 +12002,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12754,7 +12754,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12762,7 +12762,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12770,7 +12770,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12778,7 +12778,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12786,7 +12786,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12794,7 +12794,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12802,7 +12802,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12810,7 +12810,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12818,7 +12818,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12826,7 +12826,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13109,7 +13109,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13117,7 +13117,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13125,7 +13125,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13133,7 +13133,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13141,7 +13141,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13149,7 +13149,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13157,7 +13157,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13165,7 +13165,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13173,7 +13173,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13181,7 +13181,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13508,7 +13508,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13516,7 +13516,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13524,7 +13524,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13532,7 +13532,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13540,7 +13540,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13548,7 +13548,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13556,7 +13556,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13564,7 +13564,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13572,7 +13572,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13580,7 +13580,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14034,7 +14034,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14042,7 +14042,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14050,7 +14050,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14058,7 +14058,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14066,7 +14066,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14074,7 +14074,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14082,7 +14082,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14090,7 +14090,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14098,7 +14098,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14106,7 +14106,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14134,7 +14134,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14142,7 +14142,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14150,7 +14150,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14158,7 +14158,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14166,7 +14166,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14174,7 +14174,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14182,7 +14182,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14190,7 +14190,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14198,7 +14198,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14206,7 +14206,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14252,7 +14252,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14260,7 +14260,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14268,7 +14268,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14276,7 +14276,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14284,7 +14284,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14292,7 +14292,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14300,7 +14300,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14308,7 +14308,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14316,7 +14316,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14324,7 +14324,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -15103,7 +15103,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -15111,7 +15111,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -15119,7 +15119,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -15127,7 +15127,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -15135,7 +15135,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -15143,7 +15143,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -15151,7 +15151,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -15159,7 +15159,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -15167,7 +15167,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -15175,7 +15175,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -15974,7 +15974,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -15982,7 +15982,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           }
@@ -22747,6 +22747,54 @@
       }
     },
     "schemas": {
+      "query-parameter_force": {
+        "type": "boolean"
+      },
+      "query-parameter_recursive": {
+        "type": "boolean"
+      },
+      "query-parameter_fields": {
+        "type": "string"
+      },
+      "query-parameter_filter": {
+        "type": "string"
+      },
+      "query-parameter_filterEncoded": {
+        "type": "boolean"
+      },
+      "query-parameter_format": {
+        "type": "string",
+        "enum": [
+          "references",
+          "records",
+          "idrecords"
+        ]
+      },
+      "query-parameter_links": {
+        "type": "boolean"
+      },
+      "query-parameter_offset": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "query-parameter_page": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "query-parameter_pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128
+      },
+      "query-parameter_sortAsc": {
+        "type": "string"
+      },
+      "query-parameter_sortDesc": {
+        "type": "string"
+      },
+      "query-parameter_type": {
+        "type": "string"
+      },
       "vcloud_AmqpConfigurationType": {
         "title": "vcloud_AmqpConfigurationType",
         "description": "Represents a list of AMQP Configuration items",

--- a/website/30.0.json
+++ b/website/30.0.json
@@ -418,7 +418,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -426,7 +426,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -994,7 +994,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1002,7 +1002,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1419,7 +1419,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1427,7 +1427,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1623,7 +1623,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1631,7 +1631,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1995,7 +1995,7 @@
             "name": "force",
             "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -2004,7 +2004,7 @@
             "name": "recursive",
             "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3549,7 +3549,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3557,7 +3557,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3946,7 +3946,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3954,7 +3954,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4056,7 +4056,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4064,7 +4064,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -5686,7 +5686,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -5694,7 +5694,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -5702,7 +5702,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -5710,7 +5710,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -5718,7 +5718,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -5726,7 +5726,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -5734,7 +5734,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -5742,7 +5742,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -5750,7 +5750,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -5758,7 +5758,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6190,7 +6190,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6198,7 +6198,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6206,7 +6206,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6214,7 +6214,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6222,7 +6222,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6230,7 +6230,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6238,7 +6238,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6246,7 +6246,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6254,7 +6254,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6262,7 +6262,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6495,7 +6495,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6503,7 +6503,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6511,7 +6511,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6519,7 +6519,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6527,7 +6527,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6535,7 +6535,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6543,7 +6543,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6551,7 +6551,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6559,7 +6559,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6567,7 +6567,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6849,7 +6849,7 @@
             "in": "query",
             "name": "type",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_type"
             },
             "style": "form"
           },
@@ -6857,7 +6857,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6865,7 +6865,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6873,7 +6873,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6881,7 +6881,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6889,7 +6889,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6897,7 +6897,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6905,7 +6905,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6913,7 +6913,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6921,7 +6921,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6929,7 +6929,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7065,7 +7065,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7073,7 +7073,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7081,7 +7081,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7089,7 +7089,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7097,7 +7097,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7105,7 +7105,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7113,7 +7113,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7121,7 +7121,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7129,7 +7129,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7137,7 +7137,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7410,7 +7410,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7418,7 +7418,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7426,7 +7426,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7434,7 +7434,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7442,7 +7442,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7450,7 +7450,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7458,7 +7458,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7466,7 +7466,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7474,7 +7474,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7482,7 +7482,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7839,7 +7839,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7847,7 +7847,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7855,7 +7855,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7863,7 +7863,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7871,7 +7871,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7879,7 +7879,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7887,7 +7887,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7895,7 +7895,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7903,7 +7903,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7911,7 +7911,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -8644,7 +8644,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -8652,7 +8652,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -8660,7 +8660,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -8668,7 +8668,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -8676,7 +8676,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -8684,7 +8684,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -8692,7 +8692,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -8700,7 +8700,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -8708,7 +8708,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -8716,7 +8716,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -9522,7 +9522,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -9530,7 +9530,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -9538,7 +9538,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -9546,7 +9546,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -9554,7 +9554,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -9562,7 +9562,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -9570,7 +9570,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -9578,7 +9578,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -9586,7 +9586,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -9594,7 +9594,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10100,7 +10100,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10108,7 +10108,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10116,7 +10116,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10124,7 +10124,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10132,7 +10132,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10140,7 +10140,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10148,7 +10148,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10156,7 +10156,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10164,7 +10164,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10172,7 +10172,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10525,7 +10525,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10533,7 +10533,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10541,7 +10541,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10549,7 +10549,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10557,7 +10557,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10565,7 +10565,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10573,7 +10573,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10581,7 +10581,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10589,7 +10589,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10597,7 +10597,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10881,7 +10881,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10889,7 +10889,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10897,7 +10897,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10905,7 +10905,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10913,7 +10913,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10921,7 +10921,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10929,7 +10929,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10937,7 +10937,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10945,7 +10945,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10953,7 +10953,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11376,7 +11376,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11384,7 +11384,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11392,7 +11392,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11400,7 +11400,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11408,7 +11408,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11416,7 +11416,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11424,7 +11424,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11432,7 +11432,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11440,7 +11440,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11448,7 +11448,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11759,7 +11759,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11767,7 +11767,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11775,7 +11775,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11783,7 +11783,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11791,7 +11791,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11799,7 +11799,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11807,7 +11807,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11815,7 +11815,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11823,7 +11823,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11831,7 +11831,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11859,7 +11859,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11867,7 +11867,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11875,7 +11875,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11883,7 +11883,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11891,7 +11891,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11899,7 +11899,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11907,7 +11907,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11915,7 +11915,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11923,7 +11923,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11931,7 +11931,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11970,7 +11970,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11978,7 +11978,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11986,7 +11986,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11994,7 +11994,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12002,7 +12002,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12010,7 +12010,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12018,7 +12018,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12026,7 +12026,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12034,7 +12034,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12042,7 +12042,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12794,7 +12794,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12802,7 +12802,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12810,7 +12810,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12818,7 +12818,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12826,7 +12826,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12834,7 +12834,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12842,7 +12842,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12850,7 +12850,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12858,7 +12858,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12866,7 +12866,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13149,7 +13149,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13157,7 +13157,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13165,7 +13165,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13173,7 +13173,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13181,7 +13181,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13189,7 +13189,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13197,7 +13197,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13205,7 +13205,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13213,7 +13213,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13221,7 +13221,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13548,7 +13548,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13556,7 +13556,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13564,7 +13564,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13572,7 +13572,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13580,7 +13580,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13588,7 +13588,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13596,7 +13596,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13604,7 +13604,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13612,7 +13612,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13620,7 +13620,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14074,7 +14074,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14082,7 +14082,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14090,7 +14090,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14098,7 +14098,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14106,7 +14106,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14114,7 +14114,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14122,7 +14122,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14130,7 +14130,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14138,7 +14138,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14146,7 +14146,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14174,7 +14174,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14182,7 +14182,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14190,7 +14190,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14198,7 +14198,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14206,7 +14206,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14214,7 +14214,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14222,7 +14222,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14230,7 +14230,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14238,7 +14238,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14246,7 +14246,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14292,7 +14292,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14300,7 +14300,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14308,7 +14308,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14316,7 +14316,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14324,7 +14324,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14332,7 +14332,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14340,7 +14340,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14348,7 +14348,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14356,7 +14356,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14364,7 +14364,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -15245,7 +15245,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -15253,7 +15253,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -15261,7 +15261,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -15269,7 +15269,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -15277,7 +15277,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -15285,7 +15285,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -15293,7 +15293,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -15301,7 +15301,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -15309,7 +15309,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -15317,7 +15317,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -16116,7 +16116,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16124,7 +16124,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           }
@@ -22843,6 +22843,54 @@
       }
     },
     "schemas": {
+      "query-parameter_force": {
+        "type": "boolean"
+      },
+      "query-parameter_recursive": {
+        "type": "boolean"
+      },
+      "query-parameter_fields": {
+        "type": "string"
+      },
+      "query-parameter_filter": {
+        "type": "string"
+      },
+      "query-parameter_filterEncoded": {
+        "type": "boolean"
+      },
+      "query-parameter_format": {
+        "type": "string",
+        "enum": [
+          "references",
+          "records",
+          "idrecords"
+        ]
+      },
+      "query-parameter_links": {
+        "type": "boolean"
+      },
+      "query-parameter_offset": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "query-parameter_page": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "query-parameter_pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128
+      },
+      "query-parameter_sortAsc": {
+        "type": "string"
+      },
+      "query-parameter_sortDesc": {
+        "type": "string"
+      },
+      "query-parameter_type": {
+        "type": "string"
+      },
       "vcloud_AmqpConfigurationType": {
         "title": "vcloud_AmqpConfigurationType",
         "description": "Represents a list of AMQP Configuration items",

--- a/website/30.0.json
+++ b/website/30.0.json
@@ -1796,6 +1796,16 @@
           "extension"
         ],
         "description": "Update a network pool.",
+        "requestBody": {
+          "content": {
+            "application/vnd.vmware.admin.vmwNetworkPool+json;version=30.0": {
+              "schema": {
+                "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/30.0.json
+++ b/website/30.0.json
@@ -1798,7 +1798,14 @@
         "description": "Update a network pool.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.admin.vmwNetworkPool+json;version=30.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3174,6 +3181,11 @@
               "application/vnd.vmware.vcloud.site+json;version=30.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_SiteType"
+                }
+              },
+              "application/vnd.vmware.admin.siteAssociation+json;version=30.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_SiteAssociationType"
                 }
               }
             }
@@ -6936,7 +6948,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=30.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/website/30.0.json
+++ b/website/30.0.json
@@ -413,6 +413,24 @@
           "admin"
         ],
         "description": "Delete a catalog.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -971,6 +989,24 @@
           "admin"
         ],
         "description": "Delete an edge gateway.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1378,6 +1414,24 @@
           "user"
         ],
         "description": "Delete a media object.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1564,6 +1618,24 @@
           "admin"
         ],
         "description": "Delete a network.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1917,6 +1989,26 @@
           "admin"
         ],
         "description": "Delete an organization.\n\n Before you can delete an organization, you must disable it and then delete or change ownership of all objects that the organization's users own.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3452,6 +3544,24 @@
           "user"
         ],
         "description": "Delete a vApp or VM.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3831,6 +3941,24 @@
           "admin"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3923,6 +4051,24 @@
           "user"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it, unless {@code RestConstants.DeleteParameters.FORCE} is asserted",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -5535,6 +5681,88 @@
           "user"
         ],
         "description": "Retrieves a list of Catalogs by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -5957,6 +6185,88 @@
           "extension"
         ],
         "description": "Get a list of all datastores by using REST API General QueryHandler. This is read only list of datastores. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6180,6 +6490,88 @@
           "user"
         ],
         "description": "Retrieves a disk list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6452,6 +6844,96 @@
           "user"
         ],
         "description": "REST API General queries handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6578,6 +7060,88 @@
           "extension"
         ],
         "description": "Get list of external networks by using REST API general QueryHandler. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6841,6 +7405,88 @@
           "admin"
         ],
         "description": "Retrieves a list of groups for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7188,6 +7834,88 @@
           "extension"
         ],
         "description": "Get list of hosts by using REST API general QueryHAndler; This is read only list of host references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7911,6 +8639,88 @@
           "user"
         ],
         "description": "Retrieves a media list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -8707,6 +9517,88 @@
           "extension"
         ],
         "description": "Get list of network pools by using REST API general QueryHandler. This is read only list of network pool references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9203,6 +10095,88 @@
           "extension"
         ],
         "description": "Get list of Organization Networks for the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9546,6 +10520,88 @@
           "extension"
         ],
         "description": "Get list of all Organization Vdcs in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9820,6 +10876,88 @@
           "admin"
         ],
         "description": "Retrieves a list of organizations by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10233,6 +11371,88 @@
           "extension"
         ],
         "description": "Get list of provider vDCs by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10534,6 +11754,88 @@
           "admin"
         ],
         "description": "Retrieves a list of vdcs in the organization; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10552,6 +11854,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10581,6 +11965,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11323,6 +12789,88 @@
           "extension"
         ],
         "description": "Return the System Administrator representation of all extension services registered with the system.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11596,6 +13144,88 @@
           "extension"
         ],
         "description": "Get list of all stranded items in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11913,6 +13543,88 @@
           "admin"
         ],
         "description": "Retrieves a list of users for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12357,6 +14069,88 @@
           "user"
         ],
         "description": "Retrieves a list of vAppTemplates using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12375,6 +14169,88 @@
           "extension"
         ],
         "description": "Get list of all vApps in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12411,6 +14287,88 @@
           "user"
         ],
         "description": "Retrieves a list of VMs in lease by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13282,6 +15240,88 @@
           "extension"
         ],
         "description": "Get list of vSphere servers by using REST API general QueryHandler; This is read only list of vim servers and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14071,6 +16111,24 @@
           "extension"
         ],
         "description": "Retrieve a list of virtual machines that can be imported from a registered vCenter server.\n\n This request supports optional query parameters:\n\n* page \\- The page to return. The first page is page 1.\n* pageSize \\- The number of virtual machines to list on a page. An integer value between 1 and 100. The default value is 1.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/31.0.json
+++ b/website/31.0.json
@@ -1881,6 +1881,16 @@
           "extension"
         ],
         "description": "Update a network pool.",
+        "requestBody": {
+          "content": {
+            "application/vnd.vmware.admin.vmwNetworkPool+json;version=31.0": {
+              "schema": {
+                "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/31.0.json
+++ b/website/31.0.json
@@ -1883,7 +1883,14 @@
         "description": "Update a network pool.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.admin.vmwNetworkPool+json;version=31.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3260,6 +3267,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_SiteType"
                 }
+              },
+              "application/vnd.vmware.admin.siteAssociation+json;version=31.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_SiteAssociationType"
+                }
               }
             }
           }
@@ -3750,6 +3762,11 @@
               "application/vnd.vmware.vcloud.vApp+json;version=31.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_VAppType"
+                }
+              },
+              "application/vnd.vmware.vcloud.vm+json;version=31.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_VmType"
                 }
               }
             }
@@ -7198,7 +7215,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=31.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/website/31.0.json
+++ b/website/31.0.json
@@ -413,6 +413,24 @@
           "admin"
         ],
         "description": "Delete a catalog.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -971,6 +989,24 @@
           "admin"
         ],
         "description": "Delete an edge gateway.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1378,6 +1414,24 @@
           "user"
         ],
         "description": "Delete a media object.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1564,6 +1618,24 @@
           "admin"
         ],
         "description": "Delete a network.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -2002,6 +2074,26 @@
           "admin"
         ],
         "description": "Delete an organization.\n\n Before you can delete an organization, you must disable it and then delete or change ownership of all objects that the organization's users own.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3707,6 +3799,24 @@
           "user"
         ],
         "description": "Delete a vApp or VM.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4093,6 +4203,24 @@
           "admin"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4185,6 +4313,24 @@
           "user"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it, unless {@code RestConstants.DeleteParameters.FORCE} is asserted",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -5797,6 +5943,88 @@
           "user"
         ],
         "description": "Retrieves a list of Catalogs by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6219,6 +6447,88 @@
           "extension"
         ],
         "description": "Get a list of all datastores by using REST API General QueryHandler. This is read only list of datastores. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6442,6 +6752,88 @@
           "user"
         ],
         "description": "Retrieves a disk list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6714,6 +7106,96 @@
           "user"
         ],
         "description": "REST API General queries handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6840,6 +7322,88 @@
           "extension"
         ],
         "description": "Get list of external networks by using REST API general QueryHandler. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7103,6 +7667,88 @@
           "admin"
         ],
         "description": "Retrieves a list of groups for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7504,6 +8150,88 @@
           "extension"
         ],
         "description": "Get list of hosts by using REST API general QueryHAndler; This is read only list of host references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -8227,6 +8955,88 @@
           "user"
         ],
         "description": "Retrieves a media list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -8994,6 +9804,88 @@
           "extension"
         ],
         "description": "Get list of network pools by using REST API general QueryHandler. This is read only list of network pool references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9606,6 +10498,88 @@
           "extension"
         ],
         "description": "Get list of Organization Networks for the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9949,6 +10923,88 @@
           "extension"
         ],
         "description": "Get list of all Organization Vdcs in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10223,6 +11279,88 @@
           "admin"
         ],
         "description": "Retrieves a list of organizations by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10669,6 +11807,88 @@
           "extension"
         ],
         "description": "Get list of provider vDCs by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10970,6 +12190,88 @@
           "admin"
         ],
         "description": "Retrieves a list of vdcs in the organization; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10988,6 +12290,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11017,6 +12401,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11759,6 +13225,88 @@
           "extension"
         ],
         "description": "Return the System Administrator representation of all extension services registered with the system.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12032,6 +13580,88 @@
           "extension"
         ],
         "description": "Get list of all stranded items in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12349,6 +13979,88 @@
           "admin"
         ],
         "description": "Retrieves a list of users for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12819,6 +14531,88 @@
           "user"
         ],
         "description": "Retrieves a list of vAppTemplates using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12837,6 +14631,88 @@
           "extension"
         ],
         "description": "Get list of all vApps in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12873,6 +14749,88 @@
           "user"
         ],
         "description": "Retrieves a list of VMs in lease by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13829,6 +15787,88 @@
           "extension"
         ],
         "description": "Get list of vSphere servers by using REST API general QueryHandler; This is read only list of vim servers and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14618,6 +16658,24 @@
           "extension"
         ],
         "description": "Retrieve a list of virtual machines that can be imported from a registered vCenter server.\n\n This request supports optional query parameters:\n\n* page \\- The page to return. The first page is page 1.\n* pageSize \\- The number of virtual machines to list on a page. An integer value between 1 and 100. The default value is 1.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/31.0.json
+++ b/website/31.0.json
@@ -418,7 +418,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -426,7 +426,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -994,7 +994,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1002,7 +1002,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1419,7 +1419,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1427,7 +1427,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1623,7 +1623,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1631,7 +1631,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -2080,7 +2080,7 @@
             "name": "force",
             "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -2089,7 +2089,7 @@
             "name": "recursive",
             "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3804,7 +3804,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3812,7 +3812,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4208,7 +4208,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4216,7 +4216,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4318,7 +4318,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4326,7 +4326,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -5948,7 +5948,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -5956,7 +5956,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -5964,7 +5964,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -5972,7 +5972,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -5980,7 +5980,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -5988,7 +5988,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -5996,7 +5996,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6004,7 +6004,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6012,7 +6012,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6020,7 +6020,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6452,7 +6452,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6460,7 +6460,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6468,7 +6468,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6476,7 +6476,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6484,7 +6484,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6492,7 +6492,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6500,7 +6500,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6508,7 +6508,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6516,7 +6516,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6524,7 +6524,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6757,7 +6757,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6765,7 +6765,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6773,7 +6773,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6781,7 +6781,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6789,7 +6789,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6797,7 +6797,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6805,7 +6805,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6813,7 +6813,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6821,7 +6821,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6829,7 +6829,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7111,7 +7111,7 @@
             "in": "query",
             "name": "type",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_type"
             },
             "style": "form"
           },
@@ -7119,7 +7119,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7127,7 +7127,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7135,7 +7135,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7143,7 +7143,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7151,7 +7151,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7159,7 +7159,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7167,7 +7167,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7175,7 +7175,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7183,7 +7183,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7191,7 +7191,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7327,7 +7327,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7335,7 +7335,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7343,7 +7343,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7351,7 +7351,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7359,7 +7359,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7367,7 +7367,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7375,7 +7375,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7383,7 +7383,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7391,7 +7391,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7399,7 +7399,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7672,7 +7672,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7680,7 +7680,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7688,7 +7688,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7696,7 +7696,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7704,7 +7704,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7712,7 +7712,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7720,7 +7720,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7728,7 +7728,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7736,7 +7736,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7744,7 +7744,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -8155,7 +8155,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -8163,7 +8163,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -8171,7 +8171,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -8179,7 +8179,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -8187,7 +8187,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -8195,7 +8195,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -8203,7 +8203,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -8211,7 +8211,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -8219,7 +8219,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -8227,7 +8227,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -8960,7 +8960,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -8968,7 +8968,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -8976,7 +8976,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -8984,7 +8984,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -8992,7 +8992,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -9000,7 +9000,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -9008,7 +9008,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -9016,7 +9016,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -9024,7 +9024,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -9032,7 +9032,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -9809,7 +9809,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -9817,7 +9817,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -9825,7 +9825,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -9833,7 +9833,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -9841,7 +9841,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -9849,7 +9849,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -9857,7 +9857,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -9865,7 +9865,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -9873,7 +9873,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -9881,7 +9881,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10503,7 +10503,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10511,7 +10511,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10519,7 +10519,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10527,7 +10527,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10535,7 +10535,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10543,7 +10543,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10551,7 +10551,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10559,7 +10559,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10567,7 +10567,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10575,7 +10575,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10928,7 +10928,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10936,7 +10936,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10944,7 +10944,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10952,7 +10952,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10960,7 +10960,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10968,7 +10968,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10976,7 +10976,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10984,7 +10984,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10992,7 +10992,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11000,7 +11000,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11284,7 +11284,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11292,7 +11292,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11300,7 +11300,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11308,7 +11308,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11316,7 +11316,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11324,7 +11324,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11332,7 +11332,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11340,7 +11340,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11348,7 +11348,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11356,7 +11356,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11812,7 +11812,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11820,7 +11820,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11828,7 +11828,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11836,7 +11836,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11844,7 +11844,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11852,7 +11852,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11860,7 +11860,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11868,7 +11868,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11876,7 +11876,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11884,7 +11884,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12195,7 +12195,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12203,7 +12203,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12211,7 +12211,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12219,7 +12219,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12227,7 +12227,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12235,7 +12235,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12243,7 +12243,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12251,7 +12251,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12259,7 +12259,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12267,7 +12267,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12295,7 +12295,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12303,7 +12303,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12311,7 +12311,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12319,7 +12319,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12327,7 +12327,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12335,7 +12335,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12343,7 +12343,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12351,7 +12351,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12359,7 +12359,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12367,7 +12367,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12406,7 +12406,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12414,7 +12414,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12422,7 +12422,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12430,7 +12430,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12438,7 +12438,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12446,7 +12446,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12454,7 +12454,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12462,7 +12462,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12470,7 +12470,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12478,7 +12478,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13230,7 +13230,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13238,7 +13238,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13246,7 +13246,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13254,7 +13254,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13262,7 +13262,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13270,7 +13270,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13278,7 +13278,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13286,7 +13286,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13294,7 +13294,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13302,7 +13302,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13585,7 +13585,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13593,7 +13593,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13601,7 +13601,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13609,7 +13609,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13617,7 +13617,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13625,7 +13625,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13633,7 +13633,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13641,7 +13641,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13649,7 +13649,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13657,7 +13657,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13984,7 +13984,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13992,7 +13992,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14000,7 +14000,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14008,7 +14008,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14016,7 +14016,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14024,7 +14024,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14032,7 +14032,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14040,7 +14040,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14048,7 +14048,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14056,7 +14056,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14536,7 +14536,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14544,7 +14544,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14552,7 +14552,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14560,7 +14560,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14568,7 +14568,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14576,7 +14576,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14584,7 +14584,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14592,7 +14592,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14600,7 +14600,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14608,7 +14608,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14636,7 +14636,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14644,7 +14644,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14652,7 +14652,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14660,7 +14660,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14668,7 +14668,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14676,7 +14676,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14684,7 +14684,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14692,7 +14692,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14700,7 +14700,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14708,7 +14708,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14754,7 +14754,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14762,7 +14762,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14770,7 +14770,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14778,7 +14778,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14786,7 +14786,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14794,7 +14794,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14802,7 +14802,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14810,7 +14810,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14818,7 +14818,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14826,7 +14826,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -15792,7 +15792,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -15800,7 +15800,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -15808,7 +15808,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -15816,7 +15816,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -15824,7 +15824,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -15832,7 +15832,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -15840,7 +15840,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -15848,7 +15848,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -15856,7 +15856,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -15864,7 +15864,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -16663,7 +16663,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16671,7 +16671,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           }
@@ -23369,6 +23369,54 @@
       }
     },
     "schemas": {
+      "query-parameter_force": {
+        "type": "boolean"
+      },
+      "query-parameter_recursive": {
+        "type": "boolean"
+      },
+      "query-parameter_fields": {
+        "type": "string"
+      },
+      "query-parameter_filter": {
+        "type": "string"
+      },
+      "query-parameter_filterEncoded": {
+        "type": "boolean"
+      },
+      "query-parameter_format": {
+        "type": "string",
+        "enum": [
+          "references",
+          "records",
+          "idrecords"
+        ]
+      },
+      "query-parameter_links": {
+        "type": "boolean"
+      },
+      "query-parameter_offset": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "query-parameter_page": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "query-parameter_pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128
+      },
+      "query-parameter_sortAsc": {
+        "type": "string"
+      },
+      "query-parameter_sortDesc": {
+        "type": "string"
+      },
+      "query-parameter_type": {
+        "type": "string"
+      },
       "vcloud_AmqpConfigurationType": {
         "title": "vcloud_AmqpConfigurationType",
         "description": "Represents a list of AMQP Configuration items",

--- a/website/32.0.json
+++ b/website/32.0.json
@@ -1591,6 +1591,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_OrgVdcNetworkType"
                 }
+              },
+              "application/vnd.vmware.admin.vmwexternalnet+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWExternalNetworkType"
+                }
               }
             }
           }
@@ -1700,6 +1705,21 @@
               "application/vnd.vmware.vcloud.orgVdcNetwork+json;version=32.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_OrgVdcNetworkType"
+                }
+              },
+              "application/vnd.vmware.vcloud.vAppNetwork+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_VAppNetworkType"
+                }
+              },
+              "application/vnd.vmware.vcloud.network+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_NetworkType"
+                }
+              },
+              "application/vnd.vmware.admin.vmwexternalnet+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWExternalNetworkType"
                 }
               }
             }
@@ -1911,7 +1931,14 @@
         "description": "Update a network pool.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.admin.vmwNetworkPool+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -3366,6 +3393,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_SiteType"
                 }
+              },
+              "application/vnd.vmware.admin.siteAssociation+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_SiteAssociationType"
+                }
               }
             }
           }
@@ -3856,6 +3888,11 @@
               "application/vnd.vmware.vcloud.vApp+json;version=32.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_VAppType"
+                }
+              },
+              "application/vnd.vmware.vcloud.vm+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_VmType"
                 }
               }
             }
@@ -4837,7 +4874,14 @@
         "description": "List registered resource class ACL rule for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5081,7 +5125,14 @@
         "description": "Returns the API definitions registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5143,7 +5194,14 @@
         "description": "Return all API definitions.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5161,7 +5219,14 @@
         "description": "Return all API definition file descriptors.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5179,7 +5244,14 @@
         "description": "Return all Extension Service API Definitions.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5233,7 +5305,14 @@
         "description": "Returns the API filters registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7393,7 +7472,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7674,7 +7760,14 @@
         "description": "Returns all file descriptors for the API definition.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7736,7 +7829,14 @@
         "description": "Returns all file descriptors for the API definition.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -8775,7 +8875,14 @@
         "description": "Returns the links registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -10919,7 +11026,14 @@
         "description": "List all gateways for this Org vDC.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -10981,7 +11095,14 @@
         "description": "List all networks for this Org vDC.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12099,7 +12220,14 @@
         "description": "Return all extension services registered with the system.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12153,7 +12281,14 @@
         "description": "List registered resource class actions for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12215,7 +12350,14 @@
         "description": "List registered resource classes for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13361,7 +13503,14 @@
         "description": "List registered service resources for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13505,7 +13654,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -16848,7 +17004,14 @@
         "description": "List all VMs using this resource pool.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -16931,7 +17094,14 @@
         "description": "Enumerate the properties of the specified VM group",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -16960,7 +17130,14 @@
         "description": "Get all VMs from all clusters in given VM group.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=32.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/website/32.0.json
+++ b/website/32.0.json
@@ -420,6 +420,24 @@
           "admin"
         ],
         "description": "Delete a catalog.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -978,6 +996,24 @@
           "admin"
         ],
         "description": "Delete an edge gateway.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1392,6 +1428,24 @@
           "user"
         ],
         "description": "Delete a media object.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1585,6 +1639,24 @@
           "admin"
         ],
         "description": "Delete a network.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -2101,6 +2173,26 @@
           "admin"
         ],
         "description": "Delete an organization.\n\n Before you can delete an organization, you must disable it and then delete or change ownership of all objects that the organization's users own.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3813,6 +3905,24 @@
           "user"
         ],
         "description": "Delete a vApp or VM.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4199,6 +4309,24 @@
           "admin"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4291,6 +4419,24 @@
           "user"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it, unless {@code RestConstants.DeleteParameters.FORCE} is asserted",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -5938,6 +6084,88 @@
           "user"
         ],
         "description": "Retrieves a list of Catalogs by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6414,6 +6642,88 @@
           "extension"
         ],
         "description": "Get a list of all datastores by using REST API General QueryHandler. This is read only list of datastores. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6637,6 +6947,88 @@
           "user"
         ],
         "description": "Retrieves a disk list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6909,6 +7301,96 @@
           "user"
         ],
         "description": "REST API General queries handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7035,6 +7517,88 @@
           "extension"
         ],
         "description": "Get list of external networks by using REST API general QueryHandler. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7298,6 +7862,88 @@
           "admin"
         ],
         "description": "Retrieves a list of groups for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7713,6 +8359,88 @@
           "extension"
         ],
         "description": "Get list of hosts by using REST API general QueryHAndler; This is read only list of host references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -8436,6 +9164,88 @@
           "user"
         ],
         "description": "Retrieves a media list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9203,6 +10013,88 @@
           "extension"
         ],
         "description": "Get list of network pools by using REST API general QueryHandler. This is read only list of network pool references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9760,6 +10652,88 @@
           "extension"
         ],
         "description": "Get list of Organization Networks for the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10103,6 +11077,88 @@
           "extension"
         ],
         "description": "Get list of all Organization Vdcs in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10377,6 +11433,88 @@
           "admin"
         ],
         "description": "Retrieves a list of organizations by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10823,6 +11961,88 @@
           "extension"
         ],
         "description": "Get list of provider vDCs by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11124,6 +12344,88 @@
           "admin"
         ],
         "description": "Retrieves a list of vdcs in the organization; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11142,6 +12444,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11171,6 +12555,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11955,6 +13421,88 @@
           "extension"
         ],
         "description": "Return the System Administrator representation of all extension services registered with the system.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12228,6 +13776,88 @@
           "extension"
         ],
         "description": "Get list of all stranded items in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12545,6 +14175,88 @@
           "admin"
         ],
         "description": "Retrieves a list of users for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13015,6 +14727,88 @@
           "user"
         ],
         "description": "Retrieves a list of vAppTemplates using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13033,6 +14827,88 @@
           "extension"
         ],
         "description": "Get list of all vApps in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13069,6 +14945,88 @@
           "user"
         ],
         "description": "Retrieves a list of VMs in lease by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14025,6 +15983,88 @@
           "extension"
         ],
         "description": "Get list of vSphere servers by using REST API general QueryHandler; This is read only list of vim servers and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14835,6 +16875,24 @@
           "extension"
         ],
         "description": "Retrieve a list of virtual machines that can be imported from a registered vCenter server.\n\n This request supports optional query parameters:\n\n* page \\- The page to return. The first page is page 1.\n* pageSize \\- The number of virtual machines to list on a page. An integer value between 1 and 100. The default value is 1.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/32.0.json
+++ b/website/32.0.json
@@ -1929,6 +1929,16 @@
           "extension"
         ],
         "description": "Update a network pool.",
+        "requestBody": {
+          "content": {
+            "application/vnd.vmware.admin.vmwNetworkPool+json;version=32.0": {
+              "schema": {
+                "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
+              }
+            }
+          },
+          "required": true
+        },
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/32.0.json
+++ b/website/32.0.json
@@ -425,7 +425,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -433,7 +433,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1001,7 +1001,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1009,7 +1009,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1433,7 +1433,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1441,7 +1441,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1644,7 +1644,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1652,7 +1652,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -2179,7 +2179,7 @@
             "name": "force",
             "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -2188,7 +2188,7 @@
             "name": "recursive",
             "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3910,7 +3910,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3918,7 +3918,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4314,7 +4314,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4322,7 +4322,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4424,7 +4424,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4432,7 +4432,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -6089,7 +6089,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6097,7 +6097,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6105,7 +6105,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6113,7 +6113,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6121,7 +6121,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6129,7 +6129,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6137,7 +6137,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6145,7 +6145,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6153,7 +6153,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6161,7 +6161,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6647,7 +6647,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6655,7 +6655,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6663,7 +6663,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6671,7 +6671,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6679,7 +6679,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6687,7 +6687,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6695,7 +6695,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6703,7 +6703,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6711,7 +6711,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6719,7 +6719,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6952,7 +6952,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6960,7 +6960,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6968,7 +6968,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6976,7 +6976,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6984,7 +6984,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6992,7 +6992,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7000,7 +7000,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7008,7 +7008,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7016,7 +7016,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7024,7 +7024,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7306,7 +7306,7 @@
             "in": "query",
             "name": "type",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_type"
             },
             "style": "form"
           },
@@ -7314,7 +7314,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7322,7 +7322,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7330,7 +7330,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7338,7 +7338,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7346,7 +7346,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7354,7 +7354,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7362,7 +7362,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7370,7 +7370,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7378,7 +7378,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7386,7 +7386,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7522,7 +7522,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7530,7 +7530,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7538,7 +7538,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7546,7 +7546,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7554,7 +7554,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7562,7 +7562,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7570,7 +7570,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7578,7 +7578,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7586,7 +7586,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7594,7 +7594,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7867,7 +7867,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7875,7 +7875,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7883,7 +7883,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7891,7 +7891,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7899,7 +7899,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7907,7 +7907,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7915,7 +7915,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7923,7 +7923,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7931,7 +7931,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7939,7 +7939,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -8364,7 +8364,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -8372,7 +8372,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -8380,7 +8380,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -8388,7 +8388,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -8396,7 +8396,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -8404,7 +8404,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -8412,7 +8412,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -8420,7 +8420,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -8428,7 +8428,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -8436,7 +8436,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -9169,7 +9169,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -9177,7 +9177,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -9185,7 +9185,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -9193,7 +9193,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -9201,7 +9201,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -9209,7 +9209,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -9217,7 +9217,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -9225,7 +9225,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -9233,7 +9233,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -9241,7 +9241,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10018,7 +10018,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10026,7 +10026,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10034,7 +10034,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10042,7 +10042,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10050,7 +10050,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10058,7 +10058,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10066,7 +10066,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10074,7 +10074,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10082,7 +10082,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10090,7 +10090,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10657,7 +10657,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10665,7 +10665,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10673,7 +10673,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10681,7 +10681,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10689,7 +10689,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10697,7 +10697,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10705,7 +10705,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10713,7 +10713,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10721,7 +10721,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10729,7 +10729,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11082,7 +11082,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11090,7 +11090,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11098,7 +11098,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11106,7 +11106,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11114,7 +11114,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11122,7 +11122,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11130,7 +11130,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11138,7 +11138,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11146,7 +11146,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11154,7 +11154,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11438,7 +11438,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11446,7 +11446,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11454,7 +11454,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11462,7 +11462,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11470,7 +11470,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11478,7 +11478,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11486,7 +11486,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11494,7 +11494,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11502,7 +11502,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11510,7 +11510,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11966,7 +11966,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11974,7 +11974,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11982,7 +11982,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11990,7 +11990,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11998,7 +11998,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12006,7 +12006,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12014,7 +12014,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12022,7 +12022,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12030,7 +12030,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12038,7 +12038,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12349,7 +12349,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12357,7 +12357,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12365,7 +12365,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12373,7 +12373,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12381,7 +12381,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12389,7 +12389,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12397,7 +12397,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12405,7 +12405,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12413,7 +12413,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12421,7 +12421,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12449,7 +12449,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12457,7 +12457,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12465,7 +12465,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12473,7 +12473,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12481,7 +12481,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12489,7 +12489,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12497,7 +12497,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12505,7 +12505,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12513,7 +12513,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12521,7 +12521,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12560,7 +12560,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12568,7 +12568,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12576,7 +12576,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12584,7 +12584,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12592,7 +12592,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12600,7 +12600,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12608,7 +12608,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12616,7 +12616,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12624,7 +12624,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12632,7 +12632,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13426,7 +13426,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13434,7 +13434,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13442,7 +13442,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13450,7 +13450,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13458,7 +13458,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13466,7 +13466,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13474,7 +13474,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13482,7 +13482,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13490,7 +13490,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13498,7 +13498,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13781,7 +13781,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13789,7 +13789,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13797,7 +13797,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13805,7 +13805,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13813,7 +13813,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13821,7 +13821,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13829,7 +13829,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13837,7 +13837,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13845,7 +13845,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13853,7 +13853,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14180,7 +14180,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14188,7 +14188,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14196,7 +14196,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14204,7 +14204,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14212,7 +14212,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14220,7 +14220,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14228,7 +14228,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14236,7 +14236,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14244,7 +14244,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14252,7 +14252,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14732,7 +14732,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14740,7 +14740,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14748,7 +14748,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14756,7 +14756,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14764,7 +14764,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14772,7 +14772,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14780,7 +14780,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14788,7 +14788,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14796,7 +14796,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14804,7 +14804,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14832,7 +14832,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14840,7 +14840,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14848,7 +14848,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14856,7 +14856,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14864,7 +14864,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14872,7 +14872,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14880,7 +14880,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14888,7 +14888,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14896,7 +14896,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14904,7 +14904,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14950,7 +14950,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14958,7 +14958,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14966,7 +14966,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14974,7 +14974,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14982,7 +14982,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14990,7 +14990,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14998,7 +14998,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -15006,7 +15006,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -15014,7 +15014,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -15022,7 +15022,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -15988,7 +15988,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -15996,7 +15996,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -16004,7 +16004,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -16012,7 +16012,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -16020,7 +16020,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16028,7 +16028,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -16036,7 +16036,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -16044,7 +16044,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -16052,7 +16052,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -16060,7 +16060,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -16880,7 +16880,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16888,7 +16888,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           }
@@ -23775,6 +23775,54 @@
       }
     },
     "schemas": {
+      "query-parameter_force": {
+        "type": "boolean"
+      },
+      "query-parameter_recursive": {
+        "type": "boolean"
+      },
+      "query-parameter_fields": {
+        "type": "string"
+      },
+      "query-parameter_filter": {
+        "type": "string"
+      },
+      "query-parameter_filterEncoded": {
+        "type": "boolean"
+      },
+      "query-parameter_format": {
+        "type": "string",
+        "enum": [
+          "references",
+          "records",
+          "idrecords"
+        ]
+      },
+      "query-parameter_links": {
+        "type": "boolean"
+      },
+      "query-parameter_offset": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "query-parameter_page": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "query-parameter_pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128
+      },
+      "query-parameter_sortAsc": {
+        "type": "string"
+      },
+      "query-parameter_sortDesc": {
+        "type": "string"
+      },
+      "query-parameter_type": {
+        "type": "string"
+      },
       "vcloud_AmqpConfigurationType": {
         "title": "vcloud_AmqpConfigurationType",
         "description": "Represents a list of AMQP Configuration items",

--- a/website/33.0.json
+++ b/website/33.0.json
@@ -425,7 +425,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -433,7 +433,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1001,7 +1001,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1009,7 +1009,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1435,7 +1435,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1443,7 +1443,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1646,7 +1646,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1654,7 +1654,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -2198,7 +2198,7 @@
             "name": "force",
             "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -2207,7 +2207,7 @@
             "name": "recursive",
             "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3935,7 +3935,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3943,7 +3943,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4339,7 +4339,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4347,7 +4347,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4449,7 +4449,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4457,7 +4457,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -6139,7 +6139,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6147,7 +6147,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6155,7 +6155,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6163,7 +6163,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6171,7 +6171,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6179,7 +6179,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6187,7 +6187,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6195,7 +6195,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6203,7 +6203,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6211,7 +6211,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6697,7 +6697,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6705,7 +6705,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6713,7 +6713,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6721,7 +6721,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6729,7 +6729,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6737,7 +6737,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6745,7 +6745,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6753,7 +6753,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6761,7 +6761,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6769,7 +6769,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7002,7 +7002,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7010,7 +7010,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7018,7 +7018,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7026,7 +7026,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7034,7 +7034,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7042,7 +7042,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7050,7 +7050,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7058,7 +7058,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7066,7 +7066,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7074,7 +7074,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7356,7 +7356,7 @@
             "in": "query",
             "name": "type",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_type"
             },
             "style": "form"
           },
@@ -7364,7 +7364,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7372,7 +7372,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7380,7 +7380,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7388,7 +7388,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7396,7 +7396,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7404,7 +7404,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7412,7 +7412,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7420,7 +7420,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7428,7 +7428,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7436,7 +7436,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7572,7 +7572,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7580,7 +7580,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7588,7 +7588,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7596,7 +7596,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7604,7 +7604,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7612,7 +7612,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7620,7 +7620,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7628,7 +7628,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7636,7 +7636,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7644,7 +7644,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7917,7 +7917,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7925,7 +7925,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7933,7 +7933,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7941,7 +7941,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7949,7 +7949,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7957,7 +7957,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7965,7 +7965,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7973,7 +7973,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7981,7 +7981,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7989,7 +7989,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -8414,7 +8414,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -8422,7 +8422,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -8430,7 +8430,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -8438,7 +8438,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -8446,7 +8446,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -8454,7 +8454,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -8462,7 +8462,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -8470,7 +8470,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -8478,7 +8478,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -8486,7 +8486,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -9219,7 +9219,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -9227,7 +9227,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -9235,7 +9235,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -9243,7 +9243,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -9251,7 +9251,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -9259,7 +9259,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -9267,7 +9267,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -9275,7 +9275,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -9283,7 +9283,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -9291,7 +9291,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10068,7 +10068,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10076,7 +10076,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10084,7 +10084,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10092,7 +10092,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10100,7 +10100,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10108,7 +10108,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10116,7 +10116,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10124,7 +10124,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10132,7 +10132,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10140,7 +10140,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10707,7 +10707,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10715,7 +10715,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10723,7 +10723,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10731,7 +10731,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10739,7 +10739,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10747,7 +10747,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10755,7 +10755,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10763,7 +10763,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10771,7 +10771,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10779,7 +10779,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11132,7 +11132,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11140,7 +11140,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11148,7 +11148,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11156,7 +11156,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11164,7 +11164,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11172,7 +11172,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11180,7 +11180,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11188,7 +11188,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11196,7 +11196,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11204,7 +11204,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11488,7 +11488,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11496,7 +11496,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11504,7 +11504,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11512,7 +11512,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11520,7 +11520,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11528,7 +11528,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11536,7 +11536,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11544,7 +11544,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11552,7 +11552,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11560,7 +11560,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12016,7 +12016,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12024,7 +12024,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12032,7 +12032,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12040,7 +12040,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12048,7 +12048,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12056,7 +12056,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12064,7 +12064,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12072,7 +12072,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12080,7 +12080,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12088,7 +12088,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12399,7 +12399,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12407,7 +12407,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12415,7 +12415,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12423,7 +12423,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12431,7 +12431,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12439,7 +12439,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12447,7 +12447,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12455,7 +12455,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12463,7 +12463,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12471,7 +12471,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12499,7 +12499,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12507,7 +12507,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12515,7 +12515,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12523,7 +12523,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12531,7 +12531,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12539,7 +12539,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12547,7 +12547,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12555,7 +12555,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12563,7 +12563,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12571,7 +12571,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12611,7 +12611,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12619,7 +12619,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12627,7 +12627,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12635,7 +12635,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12643,7 +12643,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12651,7 +12651,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12659,7 +12659,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12667,7 +12667,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12675,7 +12675,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12683,7 +12683,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13496,7 +13496,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13504,7 +13504,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13512,7 +13512,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13520,7 +13520,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13528,7 +13528,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13536,7 +13536,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13544,7 +13544,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13552,7 +13552,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13560,7 +13560,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13568,7 +13568,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13851,7 +13851,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13859,7 +13859,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13867,7 +13867,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13875,7 +13875,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13883,7 +13883,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13891,7 +13891,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13899,7 +13899,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13907,7 +13907,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13915,7 +13915,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13923,7 +13923,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14250,7 +14250,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14258,7 +14258,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14266,7 +14266,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14274,7 +14274,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14282,7 +14282,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14290,7 +14290,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14298,7 +14298,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14306,7 +14306,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14314,7 +14314,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14322,7 +14322,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14802,7 +14802,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14810,7 +14810,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14818,7 +14818,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14826,7 +14826,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14834,7 +14834,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14842,7 +14842,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14850,7 +14850,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14858,7 +14858,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14866,7 +14866,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14874,7 +14874,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14902,7 +14902,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14910,7 +14910,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14918,7 +14918,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14926,7 +14926,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14934,7 +14934,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14942,7 +14942,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14950,7 +14950,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14958,7 +14958,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14966,7 +14966,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14974,7 +14974,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -15020,7 +15020,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -15028,7 +15028,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -15036,7 +15036,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -15044,7 +15044,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -15052,7 +15052,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -15060,7 +15060,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -15068,7 +15068,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -15076,7 +15076,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -15084,7 +15084,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -15092,7 +15092,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -16058,7 +16058,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -16066,7 +16066,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -16074,7 +16074,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -16082,7 +16082,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -16090,7 +16090,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16098,7 +16098,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -16106,7 +16106,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -16114,7 +16114,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -16122,7 +16122,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -16130,7 +16130,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -16950,7 +16950,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16958,7 +16958,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           }
@@ -23938,6 +23938,54 @@
       }
     },
     "schemas": {
+      "query-parameter_force": {
+        "type": "boolean"
+      },
+      "query-parameter_recursive": {
+        "type": "boolean"
+      },
+      "query-parameter_fields": {
+        "type": "string"
+      },
+      "query-parameter_filter": {
+        "type": "string"
+      },
+      "query-parameter_filterEncoded": {
+        "type": "boolean"
+      },
+      "query-parameter_format": {
+        "type": "string",
+        "enum": [
+          "references",
+          "records",
+          "idrecords"
+        ]
+      },
+      "query-parameter_links": {
+        "type": "boolean"
+      },
+      "query-parameter_offset": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "query-parameter_page": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "query-parameter_pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128
+      },
+      "query-parameter_sortAsc": {
+        "type": "string"
+      },
+      "query-parameter_sortDesc": {
+        "type": "string"
+      },
+      "query-parameter_type": {
+        "type": "string"
+      },
       "vcloud_AmqpConfigurationType": {
         "title": "vcloud_AmqpConfigurationType",
         "description": "Represents a list of AMQP Configuration items",

--- a/website/33.0.json
+++ b/website/33.0.json
@@ -1593,6 +1593,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_OrgVdcNetworkType"
                 }
+              },
+              "application/vnd.vmware.admin.vmwexternalnet+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWExternalNetworkType"
+                }
               }
             }
           }
@@ -1702,6 +1707,21 @@
               "application/vnd.vmware.vcloud.orgVdcNetwork+json;version=33.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_OrgVdcNetworkType"
+                }
+              },
+              "application/vnd.vmware.vcloud.vAppNetwork+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_VAppNetworkType"
+                }
+              },
+              "application/vnd.vmware.vcloud.network+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_NetworkType"
+                }
+              },
+              "application/vnd.vmware.admin.vmwexternalnet+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWExternalNetworkType"
                 }
               }
             }
@@ -1928,6 +1948,11 @@
               "application/vnd.vmware.admin.networkPool+json;version=33.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_NetworkPoolType"
+                }
+              },
+              "application/vnd.vmware.admin.vmwNetworkPool+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
                 }
               }
             }
@@ -3391,6 +3416,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_SiteType"
                 }
+              },
+              "application/vnd.vmware.admin.siteAssociation+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_SiteAssociationType"
+                }
               }
             }
           }
@@ -3881,6 +3911,11 @@
               "application/vnd.vmware.vcloud.vApp+json;version=33.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_VAppType"
+                }
+              },
+              "application/vnd.vmware.vcloud.vm+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_VmType"
                 }
               }
             }
@@ -4862,7 +4897,14 @@
         "description": "List registered resource class ACL rule for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5131,7 +5173,14 @@
         "description": "Returns the API definitions registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5193,7 +5242,14 @@
         "description": "Return all API definitions.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5211,7 +5267,14 @@
         "description": "Return all API definition file descriptors.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5229,7 +5292,14 @@
         "description": "Return all Extension Service API Definitions.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5283,7 +5353,14 @@
         "description": "Returns the API filters registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7323,6 +7400,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_EventType"
                 }
+              },
+              "application/vnd.vmware.vcloud.admin.auditEvent+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_AuditEventType"
+                }
               }
             }
           }
@@ -7443,7 +7525,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7724,7 +7813,14 @@
         "description": "Returns all file descriptors for the API definition.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7786,7 +7882,14 @@
         "description": "Returns all file descriptors for the API definition.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -8825,7 +8928,14 @@
         "description": "Returns the links registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -10969,7 +11079,14 @@
         "description": "List all gateways for this Org vDC.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -11031,7 +11148,14 @@
         "description": "List all networks for this Org vDC.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12149,7 +12273,14 @@
         "description": "Return all extension services registered with the system.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12203,7 +12334,14 @@
         "description": "List registered resource class actions for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12265,7 +12403,14 @@
         "description": "List registered resource classes for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13431,7 +13576,14 @@
         "description": "List registered service resources for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13575,7 +13727,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -16918,7 +17077,14 @@
         "description": "List all VMs using this resource pool.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -17001,7 +17167,14 @@
         "description": "Enumerate the properties of the specified VM group",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -17030,7 +17203,14 @@
         "description": "Get all VMs from all clusters in given VM group.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=33.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/website/33.0.json
+++ b/website/33.0.json
@@ -420,6 +420,24 @@
           "admin"
         ],
         "description": "Delete a catalog.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -978,6 +996,24 @@
           "admin"
         ],
         "description": "Delete an edge gateway.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1394,6 +1430,24 @@
           "user"
         ],
         "description": "Delete a media object.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1587,6 +1641,24 @@
           "admin"
         ],
         "description": "Delete a network.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -2120,6 +2192,26 @@
           "admin"
         ],
         "description": "Delete an organization.\n\n Before you can delete an organization, you must disable it and then delete or change ownership of all objects that the organization's users own.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3838,6 +3930,24 @@
           "user"
         ],
         "description": "Delete a vApp or VM.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4224,6 +4334,24 @@
           "admin"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4316,6 +4444,24 @@
           "user"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it, unless {@code RestConstants.DeleteParameters.FORCE} is asserted",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -5988,6 +6134,88 @@
           "user"
         ],
         "description": "Retrieves a list of Catalogs by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6464,6 +6692,88 @@
           "extension"
         ],
         "description": "Get a list of all datastores by using REST API General QueryHandler. This is read only list of datastores. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6687,6 +6997,88 @@
           "user"
         ],
         "description": "Retrieves a disk list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6959,6 +7351,96 @@
           "user"
         ],
         "description": "REST API General queries handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7085,6 +7567,88 @@
           "extension"
         ],
         "description": "Get list of external networks by using REST API general QueryHandler. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7348,6 +7912,88 @@
           "admin"
         ],
         "description": "Retrieves a list of groups for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7763,6 +8409,88 @@
           "extension"
         ],
         "description": "Get list of hosts by using REST API general QueryHAndler; This is read only list of host references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -8486,6 +9214,88 @@
           "user"
         ],
         "description": "Retrieves a media list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9253,6 +10063,88 @@
           "extension"
         ],
         "description": "Get list of network pools by using REST API general QueryHandler. This is read only list of network pool references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9810,6 +10702,88 @@
           "extension"
         ],
         "description": "Get list of Organization Networks for the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10153,6 +11127,88 @@
           "extension"
         ],
         "description": "Get list of all Organization Vdcs in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10427,6 +11483,88 @@
           "admin"
         ],
         "description": "Retrieves a list of organizations by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10873,6 +12011,88 @@
           "extension"
         ],
         "description": "Get list of provider vDCs by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11174,6 +12394,88 @@
           "admin"
         ],
         "description": "Retrieves a list of vdcs in the organization; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11192,6 +12494,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11222,6 +12606,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12025,6 +13491,88 @@
           "extension"
         ],
         "description": "Return the System Administrator representation of all extension services registered with the system.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12298,6 +13846,88 @@
           "extension"
         ],
         "description": "Get list of all stranded items in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12615,6 +14245,88 @@
           "admin"
         ],
         "description": "Retrieves a list of users for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13085,6 +14797,88 @@
           "user"
         ],
         "description": "Retrieves a list of vAppTemplates using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13103,6 +14897,88 @@
           "extension"
         ],
         "description": "Get list of all vApps in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13139,6 +15015,88 @@
           "user"
         ],
         "description": "Retrieves a list of VMs in lease by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14095,6 +16053,88 @@
           "extension"
         ],
         "description": "Get list of vSphere servers by using REST API general QueryHandler; This is read only list of vim servers and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14905,6 +16945,24 @@
           "extension"
         ],
         "description": "Retrieve a list of virtual machines that can be imported from a registered vCenter server.\n\n This request supports optional query parameters:\n\n* page \\- The page to return. The first page is page 1.\n* pageSize \\- The number of virtual machines to list on a page. An integer value between 1 and 100. The default value is 1.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",

--- a/website/34.0.json
+++ b/website/34.0.json
@@ -1593,6 +1593,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_OrgVdcNetworkType"
                 }
+              },
+              "application/vnd.vmware.admin.vmwexternalnet+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWExternalNetworkType"
+                }
               }
             }
           }
@@ -1702,6 +1707,21 @@
               "application/vnd.vmware.vcloud.orgVdcNetwork+json;version=34.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_OrgVdcNetworkType"
+                }
+              },
+              "application/vnd.vmware.vcloud.vAppNetwork+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_VAppNetworkType"
+                }
+              },
+              "application/vnd.vmware.vcloud.network+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_NetworkType"
+                }
+              },
+              "application/vnd.vmware.admin.vmwexternalnet+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWExternalNetworkType"
                 }
               }
             }
@@ -1928,6 +1948,11 @@
               "application/vnd.vmware.admin.networkPool+json;version=34.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_NetworkPoolType"
+                }
+              },
+              "application/vnd.vmware.admin.vmwNetworkPool+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud-ext_VMWNetworkPoolType"
                 }
               }
             }
@@ -3391,6 +3416,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_SiteType"
                 }
+              },
+              "application/vnd.vmware.admin.siteAssociation+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_SiteAssociationType"
+                }
               }
             }
           }
@@ -3881,6 +3911,11 @@
               "application/vnd.vmware.vcloud.vApp+json;version=34.0": {
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_VAppType"
+                }
+              },
+              "application/vnd.vmware.vcloud.vm+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_VmType"
                 }
               }
             }
@@ -4862,7 +4897,14 @@
         "description": "List registered resource class ACL rule for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5105,7 +5147,14 @@
         "description": "Returns the API definitions registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5167,7 +5216,14 @@
         "description": "Return all API definitions.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5185,7 +5241,14 @@
         "description": "Return all API definition file descriptors.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5203,7 +5266,14 @@
         "description": "Return all Extension Service API Definitions.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -5257,7 +5327,14 @@
         "description": "Returns the API filters registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7297,6 +7374,11 @@
                 "schema": {
                   "$ref": "#/components/schemas/vcloud_EventType"
                 }
+              },
+              "application/vnd.vmware.vcloud.admin.auditEvent+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_AuditEventType"
+                }
               }
             }
           }
@@ -7417,7 +7499,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7698,7 +7787,14 @@
         "description": "Returns all file descriptors for the API definition.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -7760,7 +7856,14 @@
         "description": "Returns all file descriptors for the API definition.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -8801,7 +8904,14 @@
         "description": "Returns the links registered by this service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -10947,7 +11057,14 @@
         "description": "List all gateways for this Org vDC.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -11009,7 +11126,14 @@
         "description": "List all networks for this Org vDC.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12127,7 +12251,14 @@
         "description": "Return all extension services registered with the system.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12181,7 +12312,14 @@
         "description": "List registered resource class actions for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -12243,7 +12381,14 @@
         "description": "List registered resource classes for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13409,7 +13554,14 @@
         "description": "List registered service resources for extension service.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -13553,7 +13705,14 @@
         ],
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -16844,7 +17003,14 @@
         "description": "List all VMs using this resource pool.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -16928,7 +17094,14 @@
         "description": "Enumerate the properties of the specified VM group",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [
@@ -16957,7 +17130,14 @@
         "description": "Get all VMs from all clusters in given VM group.",
         "responses": {
           "2XX": {
-            "description": "success"
+            "description": "success",
+            "content": {
+              "application/vnd.vmware.vcloud.query.references+json;version=34.0": {
+                "schema": {
+                  "$ref": "#/components/schemas/vcloud_ReferencesType"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/website/34.0.json
+++ b/website/34.0.json
@@ -425,7 +425,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -433,7 +433,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1001,7 +1001,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1009,7 +1009,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1435,7 +1435,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1443,7 +1443,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -1646,7 +1646,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -1654,7 +1654,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -2198,7 +2198,7 @@
             "name": "force",
             "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -2207,7 +2207,7 @@
             "name": "recursive",
             "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -3935,7 +3935,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -3943,7 +3943,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4339,7 +4339,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4347,7 +4347,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -4449,7 +4449,7 @@
             "in": "query",
             "name": "force",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_force"
             },
             "style": "form"
           },
@@ -4457,7 +4457,7 @@
             "in": "query",
             "name": "recursive",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_recursive"
             },
             "style": "form"
           }
@@ -6113,7 +6113,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6121,7 +6121,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6129,7 +6129,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6137,7 +6137,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6145,7 +6145,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6153,7 +6153,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6161,7 +6161,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6169,7 +6169,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6177,7 +6177,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6185,7 +6185,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6671,7 +6671,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6679,7 +6679,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6687,7 +6687,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -6695,7 +6695,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -6703,7 +6703,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -6711,7 +6711,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -6719,7 +6719,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -6727,7 +6727,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -6735,7 +6735,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -6743,7 +6743,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -6976,7 +6976,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -6984,7 +6984,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -6992,7 +6992,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7000,7 +7000,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7008,7 +7008,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7016,7 +7016,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7024,7 +7024,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7032,7 +7032,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7040,7 +7040,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7048,7 +7048,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7330,7 +7330,7 @@
             "in": "query",
             "name": "type",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_type"
             },
             "style": "form"
           },
@@ -7338,7 +7338,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7346,7 +7346,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7354,7 +7354,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7362,7 +7362,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7370,7 +7370,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7378,7 +7378,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7386,7 +7386,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7394,7 +7394,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7402,7 +7402,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7410,7 +7410,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7546,7 +7546,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7554,7 +7554,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7562,7 +7562,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7570,7 +7570,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7578,7 +7578,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7586,7 +7586,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7594,7 +7594,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7602,7 +7602,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7610,7 +7610,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7618,7 +7618,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -7891,7 +7891,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -7899,7 +7899,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -7907,7 +7907,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -7915,7 +7915,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -7923,7 +7923,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -7931,7 +7931,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -7939,7 +7939,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -7947,7 +7947,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -7955,7 +7955,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -7963,7 +7963,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -8388,7 +8388,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -8396,7 +8396,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -8404,7 +8404,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -8412,7 +8412,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -8420,7 +8420,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -8428,7 +8428,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -8436,7 +8436,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -8444,7 +8444,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -8452,7 +8452,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -8460,7 +8460,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -9197,7 +9197,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -9205,7 +9205,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -9213,7 +9213,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -9221,7 +9221,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -9229,7 +9229,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -9237,7 +9237,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -9245,7 +9245,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -9253,7 +9253,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -9261,7 +9261,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -9269,7 +9269,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10046,7 +10046,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10054,7 +10054,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10062,7 +10062,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10070,7 +10070,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10078,7 +10078,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10086,7 +10086,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10094,7 +10094,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10102,7 +10102,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10110,7 +10110,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10118,7 +10118,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -10685,7 +10685,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -10693,7 +10693,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -10701,7 +10701,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -10709,7 +10709,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -10717,7 +10717,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -10725,7 +10725,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -10733,7 +10733,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -10741,7 +10741,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -10749,7 +10749,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -10757,7 +10757,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11110,7 +11110,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11118,7 +11118,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11126,7 +11126,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11134,7 +11134,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11142,7 +11142,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11150,7 +11150,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11158,7 +11158,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11166,7 +11166,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11174,7 +11174,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11182,7 +11182,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11466,7 +11466,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -11474,7 +11474,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -11482,7 +11482,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -11490,7 +11490,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -11498,7 +11498,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -11506,7 +11506,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -11514,7 +11514,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -11522,7 +11522,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -11530,7 +11530,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -11538,7 +11538,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -11994,7 +11994,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12002,7 +12002,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12010,7 +12010,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12018,7 +12018,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12026,7 +12026,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12034,7 +12034,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12042,7 +12042,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12050,7 +12050,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12058,7 +12058,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12066,7 +12066,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12377,7 +12377,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12385,7 +12385,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12393,7 +12393,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12401,7 +12401,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12409,7 +12409,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12417,7 +12417,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12425,7 +12425,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12433,7 +12433,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12441,7 +12441,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12449,7 +12449,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12477,7 +12477,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12485,7 +12485,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12493,7 +12493,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12501,7 +12501,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12509,7 +12509,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12517,7 +12517,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12525,7 +12525,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12533,7 +12533,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12541,7 +12541,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12549,7 +12549,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -12589,7 +12589,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -12597,7 +12597,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -12605,7 +12605,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -12613,7 +12613,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -12621,7 +12621,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -12629,7 +12629,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -12637,7 +12637,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -12645,7 +12645,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -12653,7 +12653,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -12661,7 +12661,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13474,7 +13474,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13482,7 +13482,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13490,7 +13490,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13498,7 +13498,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13506,7 +13506,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13514,7 +13514,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13522,7 +13522,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13530,7 +13530,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13538,7 +13538,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13546,7 +13546,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -13829,7 +13829,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -13837,7 +13837,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -13845,7 +13845,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -13853,7 +13853,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -13861,7 +13861,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -13869,7 +13869,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -13877,7 +13877,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -13885,7 +13885,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -13893,7 +13893,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -13901,7 +13901,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14202,7 +14202,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14210,7 +14210,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14218,7 +14218,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14226,7 +14226,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14234,7 +14234,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14242,7 +14242,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14250,7 +14250,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14258,7 +14258,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14266,7 +14266,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14274,7 +14274,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14754,7 +14754,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14762,7 +14762,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14770,7 +14770,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14778,7 +14778,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14786,7 +14786,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14794,7 +14794,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14802,7 +14802,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14810,7 +14810,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14818,7 +14818,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14826,7 +14826,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14854,7 +14854,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14862,7 +14862,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14870,7 +14870,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14878,7 +14878,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -14886,7 +14886,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -14894,7 +14894,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -14902,7 +14902,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -14910,7 +14910,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -14918,7 +14918,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -14926,7 +14926,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -14972,7 +14972,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -14980,7 +14980,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -14988,7 +14988,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -14996,7 +14996,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -15004,7 +15004,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -15012,7 +15012,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -15020,7 +15020,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -15028,7 +15028,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -15036,7 +15036,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -15044,7 +15044,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -15984,7 +15984,7 @@
             "in": "query",
             "name": "filter",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filter"
             },
             "style": "form"
           },
@@ -15992,7 +15992,7 @@
             "in": "query",
             "name": "sortAsc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortAsc"
             },
             "style": "form"
           },
@@ -16000,7 +16000,7 @@
             "in": "query",
             "name": "sortDesc",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_sortDesc"
             },
             "style": "form"
           },
@@ -16008,7 +16008,7 @@
             "in": "query",
             "name": "format",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_format"
             },
             "style": "form"
           },
@@ -16016,7 +16016,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16024,7 +16024,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           },
@@ -16032,7 +16032,7 @@
             "in": "query",
             "name": "offset",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_offset"
             },
             "style": "form"
           },
@@ -16040,7 +16040,7 @@
             "in": "query",
             "name": "fields",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_fields"
             },
             "style": "form"
           },
@@ -16048,7 +16048,7 @@
             "in": "query",
             "name": "filterEncoded",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_filterEncoded"
             },
             "style": "form"
           },
@@ -16056,7 +16056,7 @@
             "in": "query",
             "name": "links",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_links"
             },
             "style": "form"
           }
@@ -16876,7 +16876,7 @@
             "in": "query",
             "name": "page",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_page"
             },
             "style": "form"
           },
@@ -16884,7 +16884,7 @@
             "in": "query",
             "name": "pageSize",
             "schema": {
-              "type": "string"
+              "$ref": "#/components/schemas/query-parameter_pageSize"
             },
             "style": "form"
           }
@@ -23448,6 +23448,54 @@
       }
     },
     "schemas": {
+      "query-parameter_force": {
+        "type": "boolean"
+      },
+      "query-parameter_recursive": {
+        "type": "boolean"
+      },
+      "query-parameter_fields": {
+        "type": "string"
+      },
+      "query-parameter_filter": {
+        "type": "string"
+      },
+      "query-parameter_filterEncoded": {
+        "type": "boolean"
+      },
+      "query-parameter_format": {
+        "type": "string",
+        "enum": [
+          "references",
+          "records",
+          "idrecords"
+        ]
+      },
+      "query-parameter_links": {
+        "type": "boolean"
+      },
+      "query-parameter_offset": {
+        "type": "integer",
+        "minimum": 0
+      },
+      "query-parameter_page": {
+        "type": "integer",
+        "minimum": 1
+      },
+      "query-parameter_pageSize": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 128
+      },
+      "query-parameter_sortAsc": {
+        "type": "string"
+      },
+      "query-parameter_sortDesc": {
+        "type": "string"
+      },
+      "query-parameter_type": {
+        "type": "string"
+      },
       "vcloud_AmqpConfigurationType": {
         "title": "vcloud_AmqpConfigurationType",
         "description": "Represents a list of AMQP Configuration items",

--- a/website/34.0.json
+++ b/website/34.0.json
@@ -420,6 +420,24 @@
           "admin"
         ],
         "description": "Delete a catalog.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -978,6 +996,24 @@
           "admin"
         ],
         "description": "Delete an edge gateway.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1394,6 +1430,24 @@
           "user"
         ],
         "description": "Delete a media object.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -1587,6 +1641,24 @@
           "admin"
         ],
         "description": "Delete a network.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -2120,6 +2192,26 @@
           "admin"
         ],
         "description": "Delete an organization.\n\n Before you can delete an organization, you must disable it and then delete or change ownership of all objects that the organization's users own.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "description": "pass force=true as query parameter along with recursive=true to remove an organization or VDC and any objects it contains, regardless of their state.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "description": "pass recursive=true as query parameter to remove an organization or VDC and any objects it contains that are in a state that normally allows removal.",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -3838,6 +3930,24 @@
           "user"
         ],
         "description": "Delete a vApp or VM.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4224,6 +4334,24 @@
           "admin"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -4316,6 +4444,24 @@
           "user"
         ],
         "description": "Delete an organization vDC.\n\n You must disable the virtual datacenter before you can delete it, unless {@code RestConstants.DeleteParameters.FORCE} is asserted",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "force",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "recursive",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",
@@ -5962,6 +6108,88 @@
           "user"
         ],
         "description": "Retrieves a list of Catalogs by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6438,6 +6666,88 @@
           "extension"
         ],
         "description": "Get a list of all datastores by using REST API General QueryHandler. This is read only list of datastores. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6661,6 +6971,88 @@
           "user"
         ],
         "description": "Retrieves a disk list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -6933,6 +7325,96 @@
           "user"
         ],
         "description": "REST API General queries handler",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "type",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7059,6 +7541,88 @@
           "extension"
         ],
         "description": "Get list of external networks by using REST API general QueryHandler. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7322,6 +7886,88 @@
           "admin"
         ],
         "description": "Retrieves a list of groups for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -7737,6 +8383,88 @@
           "extension"
         ],
         "description": "Get list of hosts by using REST API general QueryHAndler; This is read only list of host references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -8464,6 +9192,88 @@
           "user"
         ],
         "description": "Retrieves a media list by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9231,6 +10041,88 @@
           "extension"
         ],
         "description": "Get list of network pools by using REST API general QueryHandler. This is read only list of network pool references and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -9788,6 +10680,88 @@
           "extension"
         ],
         "description": "Get list of Organization Networks for the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10131,6 +11105,88 @@
           "extension"
         ],
         "description": "Get list of all Organization Vdcs in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10405,6 +11461,88 @@
           "admin"
         ],
         "description": "Retrieves a list of organizations by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -10851,6 +11989,88 @@
           "extension"
         ],
         "description": "Get list of provider vDCs by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11152,6 +12372,88 @@
           "admin"
         ],
         "description": "Retrieves a list of vdcs in the organization; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11170,6 +12472,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -11200,6 +12584,88 @@
           "admin"
         ],
         "description": "Retrieves a list of roles in the cloud by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12003,6 +13469,88 @@
           "extension"
         ],
         "description": "Return the System Administrator representation of all extension services registered with the system.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12276,6 +13824,88 @@
           "extension"
         ],
         "description": "Get list of all stranded items in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references, records or idrecords. Default format is records.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -12567,6 +14197,88 @@
           "admin"
         ],
         "description": "Retrieves a list of users for organization the org admin belongs to by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13037,6 +14749,88 @@
           "user"
         ],
         "description": "Retrieves a list of vAppTemplates using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13055,6 +14849,88 @@
           "extension"
         ],
         "description": "Get list of all vApps in the system by using REST API general QueryHandler. This is read only list and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -13091,6 +14967,88 @@
           "user"
         ],
         "description": "Retrieves a list of VMs in lease by using REST API general QueryHandler; If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- references or records. Default format is references.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14021,6 +15979,88 @@
           "extension"
         ],
         "description": "Get list of vSphere servers by using REST API general QueryHandler; This is read only list of vim servers and is not bound to specific states. If filter is provided it will be applied to the corresponding result set. Format determines the elements representation \\- referenceView or simpleView. Default format is referenceView.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "filter",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortAsc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "sortDesc",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "fields",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "filterEncoded",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "links",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success"
@@ -14831,6 +16871,24 @@
           "extension"
         ],
         "description": "Retrieve a list of virtual machines that can be imported from a registered vCenter server.\n\n This request supports optional query parameters:\n\n* page \\- The page to return. The first page is page 1.\n* pageSize \\- The number of virtual machines to list on a page. An integer value between 1 and 100. The default value is 1.",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          },
+          {
+            "in": "query",
+            "name": "pageSize",
+            "schema": {
+              "type": "string"
+            },
+            "style": "form"
+          }
+        ],
         "responses": {
           "2XX": {
             "description": "success",


### PR DESCRIPTION
Add query parameters, for example:
https://code.vmware.com/apis/553/vmware-cloud-director/doc/doc/operations/GET-ExecuteQuery.html

Support multiple output types, for example:
https://code.vmware.com/apis/553/vmware-cloud-director/doc/doc/operations/GET-ExternalOrOrgNetwork.html

Better support input types by supporting a few cases where they were previously missed.